### PR TITLE
Create unique user id (uuid) and save to db

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -478,12 +478,14 @@ function Slackbot(configuration) {
                                             slack_botkit.trigger('update_team', [bot, team]);
                                         }
 
-                                        slack_botkit.storage.users.get(identity.user_id, function(err, user) {
+                                        var uuid = identity.team_id + '_' + identity.user_id;
+                                       
+                                        slack_botkit.storage.users.get(uuid, function(err, user) {
                                             isnew = false;
                                             if (!user) {
                                                 isnew = true;
                                                 user = {
-                                                    id: identity.user_id,
+                                                    id: uuid,
                                                     team_id: identity.team_id,
                                                     user: identity.user,
                                                 };


### PR DESCRIPTION
There is no guarantee that Slack's user id is unique across all teams.  Therefore, prepend team_id to guarantee uniqueness.